### PR TITLE
fix(github): allow github login with 2fa

### DIFF
--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -166,7 +166,7 @@ describe('prompts', () => {
         githubPassword: password,
       })
       .then(() => {
-        expect(Github).toBeCalledWith(username, password);
+        expect(Github).toBeCalledWith(username, password, expect.any(Function));
         expect(Github.prototype.createRepository).toBeCalledWith({
           name,
           description,

--- a/src/app/lib/github.js
+++ b/src/app/lib/github.js
@@ -3,7 +3,14 @@ import request from 'request-promise';
 import uuid from 'uuid/v4';
 
 export default class Github {
-  constructor(username, password) {
+  /**
+   * Github
+   * @param {string}   username github username
+   * @param {string}   password github password
+   * @param {function} on2fa    async function that should return
+   *                            two-factor authentication pin (string)
+   */
+  constructor(username, password, on2fa) {
     this.username = username;
     this.password = password;
 
@@ -11,6 +18,7 @@ export default class Github {
       auth: {
         username,
         password,
+        on2fa,
       },
     });
   }

--- a/src/app/prompter.js
+++ b/src/app/prompter.js
@@ -201,7 +201,7 @@ export default class Prompter {
     } = this.props;
     const { githubPassword: password } = await this._promptGithubPassword();
 
-    this.props.github = new Github(username, password);
+    this.props.github = new Github(username, password, () => this.github2fa());
 
     if (semanticRelease) {
       this.props.githubToken = await this.props.github.createToken(repository);
@@ -233,6 +233,21 @@ export default class Prompter {
         type: 'password',
       },
     ]);
+  }
+
+  _promptGithub2fa() {
+    return this.generator.prompt([
+      {
+        name: 'github2fa',
+        message: `Enter your github two-factor authentication Code:`,
+        type: 'password',
+      },
+    ]);
+  }
+
+  async github2fa() {
+    const { github2fa } = await this._promptGithub2fa();
+    return github2fa;
   }
 
   /*


### PR DESCRIPTION
fix #19

## PR Type

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

allow github login with two-factor authentication.
prompt for 2fa code if needed. 

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, -->

<!-- please also describe the impact and migration path for existing applications -->

* [ ] Yes
* [x] No

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->

<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the [`contributing.md`](https://github.com/sharvit/generator-node-mdl/blob/master/contributing.md).
