### PR TITLE
feat(webpack): build your lib using webpack

### DIFF
--- a/src/app/generators/project/index.js
+++ b/src/app/generators/project/index.js
@@ -45,6 +45,10 @@ export default class extends BaseGenerator {
         templatePath: 'config/jest.config.js',
         destinationPath: 'config/jest.config.js',
       },
+      {
+        templatePath: 'config/webpack.config.js',
+        destinationPath: 'config/webpack.config.js',
+      },
     ];
 
     if (this.options.esdoc) {

--- a/src/app/generators/project/templates/_babelrc
+++ b/src/app/generators/project/templates/_babelrc
@@ -6,6 +6,5 @@
         "targets": { "node": 8 }
       }
     ]
-  ],
-  "plugins": ["add-module-exports"]
+  ]
 }

--- a/src/app/generators/project/templates/_package.json
+++ b/src/app/generators/project/templates/_package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "<%= runScriptCommand %> build:babel<% if (esdoc) { %> && <%= runScriptCommand %> build:docs<% } %>",
-    "build:babel": "babel src --out-dir dist --ignore **/*.test.js",<% if (esdoc) { %>
+    "build": "<%= runScriptCommand %> build:webpack<% if (esdoc) { %> && <%= runScriptCommand %> build:docs<% } %>",
+    "build:webpack": "webpack --config ./config/webpack.config.js",<% if (esdoc) { %>
     "build:docs": "esdoc -c ./config/esdoc.config.js",
     "develop:docs": "watch \"<%= runScriptCommand %> build:docs\" . --ignoreDirectoryPattern='/node_modules|docs|dist|coverage|.git|.nyc*./'",<% } %>
     "test:watch": "jest --config ./config/jest.config.js --watch",
@@ -34,7 +34,6 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",<% if (semanticRelease) { %>
     "@commitlint/cli": "^8.1.0",
@@ -42,6 +41,7 @@
     "@commitlint/travis-cli": "^8.1.0",<% } %>
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.8.0",
+    "babel-loader": "^8.0.6",
     "babel-plugin-add-module-exports": "^1.0.0",<% if (semanticRelease) { %>
     "commitlint-config-cz": "^0.12.0",<% } %><% if (coveralls) { %>
     "coveralls": "^3.0.2",<% } %><% if (esdoc) { %>
@@ -58,7 +58,9 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.8.0",
     "prettier": "^1.15.3",
-    "rimraf": "^3.0.0"
+    "rimraf": "^3.0.0",
+    "webpack": "^4.41.4",
+    "webpack-cli": "^3.3.10"
   },<% if (semanticRelease) { %>
   "optionalDependencies": {<% if (semanticRelease) { %>
     "cz-conventional-changelog": "^3.0.2",<% } %>

--- a/src/app/generators/project/templates/config/webpack.config.js
+++ b/src/app/generators/project/templates/config/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const config = {
+  mode: 'production',
+  target: 'node',
+
+  entry: path.resolve(__dirname, '../src/index.js'),
+
+  output: {
+    path: path.resolve(__dirname, '../dist'),
+    filename: 'index.js',
+    library: '<%= projectName %>',
+    libraryTarget: 'umd',
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+    ],
+  },
+};
+
+module.exports = config;

--- a/src/app/generators/project/templates/src/index.js
+++ b/src/app/generators/project/templates/src/index.js
@@ -4,3 +4,10 @@
  * @return {String} return the recived import.
  */
 export default (input = 'No args passed!') => input;
+
+/**
+ * Return the passed argument as is.
+ * @param  {String} [input='No args passed!'] input argument to return.
+ * @return {String} return the recived import.
+ */
+export const namedExport = (input = 'No args passed!') => input;

--- a/src/app/generators/project/templates/src/index.test.js
+++ b/src/app/generators/project/templates/src/index.test.js
@@ -1,6 +1,9 @@
-import <%= camelProject %> from '.';
+import <%= camelProject %>, { namedExport } from './index';
 
 test('output', () => {
   expect(<%= camelProject %>('🐰')).toBe('🐰');
   expect(<%= camelProject %>()).toBe('No args passed!');
+
+  expect(namedExport('🐰')).toBe('🐰');
+  expect(namedExport()).toBe('No args passed!');
 });

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -43,6 +43,7 @@ test('default files', () => {
         'package.json',
         'readme.md',
         'config/jest.config.js',
+        'config/webpack.config.js',
         'src/index.js',
         'src/index.test.js',
         // esdoc
@@ -95,6 +96,7 @@ test('default files with --noDefaults', () => {
         'package.json',
         'readme.md',
         'config/jest.config.js',
+        'config/webpack.config.js',
         'src/index.js',
         'src/index.test.js',
       ]);


### PR DESCRIPTION
dropped building with @babel/cli in favor of using webpack

BREAKING CHANGE: @babel/cli dropped and the build script uses webpack and babel-loader

<!---
  Please read the contribution guide before sending your first commit:
   https://github.com/sharvit/generator-node-mdl/blob/master/contributing.md)
-->

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

