### PR TITLE
fix(travis): fix gem install travis

### DIFF
--- a/src/app/generators/travis/index.js
+++ b/src/app/generators/travis/index.js
@@ -52,7 +52,7 @@ export default class extends BaseGenerator {
     const { repository, githubToken } = this.options;
 
     this.commander.run([
-      'gem install travis --no-ri --no-rdoc --quiet',
+      'gem install travis --no-document --quiet',
       `travis login --github-token ${githubToken}`,
       `travis enable -r ${repository}`,
     ]);


### PR DESCRIPTION
When running `gem install travis`, the opts `--no-ri` and `--no-rdoc`
are deprecated.
Switched to `--no-document`.

fix #77

<!---
  Please read the contribution guide before sending your first commit:
   https://github.com/sharvit/generator-node-mdl/blob/master/contributing.md)

  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:
